### PR TITLE
Add button to open current song in the spotify web player

### DIFF
--- a/src/presenters/postGuess.tsx
+++ b/src/presenters/postGuess.tsx
@@ -20,8 +20,7 @@ export const PostGuessPresenter = observer(
       props.model.nextRound()
     }
     function openSpotifyACB() {
-      window.open("https://open.spotify.com/track/" + props.model.songs[props.model.currentSong].id, '_blank').focus();
-
+      window.open("https://open.spotify.com/track/" + props.model.songs[props.model.currentSong].id, '_blank')?.focus();
     }
     function hideSpotifyButton() {
       return props.model.isGuest || !props.model.songs[props.model.currentSong].id

--- a/src/presenters/postGuess.tsx
+++ b/src/presenters/postGuess.tsx
@@ -12,6 +12,7 @@ export const PostGuessPresenter = observer(
         nextRound={nextRoundACB}
         openSpotify={openSpotifyACB}
         isGuest={props.model.isGuest}
+        hideSpotifyButton={hideSpotifyButton()}
       />
     )
     function nextRoundACB() {
@@ -21,6 +22,9 @@ export const PostGuessPresenter = observer(
     function openSpotifyACB() {
       window.open("https://open.spotify.com/track/" + props.model.songs[props.model.currentSong].id, '_blank').focus();
 
+    }
+    function hideSpotifyButton() {
+      return props.model.isGuest || !props.model.songs[props.model.currentSong].id
     }
 
     function getGuessParams() {

--- a/src/presenters/postGuess.tsx
+++ b/src/presenters/postGuess.tsx
@@ -3,21 +3,27 @@ import { PostGuessView } from "../views/postGuessView";
 import { getParamsFromUrl } from "../utils/pathUtil";
 
 export const PostGuessPresenter = observer(
-  function postGuessRender(props: { model: { songs: [{ title: string, artist: string }], currentSong: number, startTimer: Function, nextRound: Function, setCurrentScore: Function } }) {
+  function postGuessRender(props: { model: Model }) {
     return (
       <PostGuessView
         artistGuess={getParamsFromUrl("artist")}
         songGuess={getParamsFromUrl("title")}
         correctSong={{ "artist": props.model.songs[props.model.currentSong].artist, "title": props.model.songs[props.model.currentSong].title }}
         nextRound={nextRoundACB}
+        openSpotify={openSpotifyACB}
+        isGuest={props.model.isGuest}
       />
     )
     function nextRoundACB() {
       getGuessParams();
       props.model.nextRound()
     }
+    function openSpotifyACB() {
+      window.open("https://open.spotify.com/track/" + props.model.songs[props.model.currentSong].id, '_blank').focus();
 
-    function getGuessParams(){
+    }
+
+    function getGuessParams() {
       const title = getParamsFromUrl("title")
       const artist = getParamsFromUrl("artist")
       props.model.setCurrentScore(artist, title)

--- a/src/utils/spotifySource.tsx
+++ b/src/utils/spotifySource.tsx
@@ -128,8 +128,8 @@ function extractSongInfoACB(items: any[]) {
   return items.map(itemToInfoACB)
 }
 
-function itemToInfoACB(item: { track: { artists: { name: any; }[]; name: any; }; }) {
-  return { "artist": item.track.artists[0].name, "title": item.track.name }
+function itemToInfoACB(item: { track: { artists: { name: any; }[]; name: any; id: string }; }) {
+  return { "artist": item.track.artists[0].name, "title": item.track.name, "id": item.track.id }
 }
 
 function callLyricApi(songs: { artist: any; title: any; }[], numSongs: number) {

--- a/src/views/postGuessView.tsx
+++ b/src/views/postGuessView.tsx
@@ -11,9 +11,14 @@ export function PostGuessView(props: any) {
 
         {songInformationComponent("Your Guess:", props.songGuess, props.artistGuess)}
         {songInformationComponent("Correct Answer", props.correctSong.title, props.correctSong.artist)}
-        <button onClick={props.nextRound} className="font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">
-          Next Song
-        </button>
+        <div className="flex justify-center h-full">
+          <button hidden={props.isGuest} onClick={props.openSpotify} className="mr-5 flex-2/3 font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">
+            Listen to Song on Spotify
+          </button>
+          <button onClick={props.nextRound} className="font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">
+            Next Song
+          </button>
+        </div>
       </div>
     </div>
 

--- a/src/views/postGuessView.tsx
+++ b/src/views/postGuessView.tsx
@@ -12,7 +12,7 @@ export function PostGuessView(props: any) {
         {songInformationComponent("Your Guess:", props.songGuess, props.artistGuess)}
         {songInformationComponent("Correct Answer", props.correctSong.title, props.correctSong.artist)}
         <div className="flex justify-center h-full">
-          <button hidden={props.isGuest} onClick={props.openSpotify} className="mr-5 flex-2/3 font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">
+          <button hidden={props.hideSpotifyButton} onClick={props.openSpotify} className="mr-5 flex-2/3 font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">
             Listen to Song on Spotify
           </button>
           <button onClick={props.nextRound} className="font-mono w-35 rounded-full bg-white hover:bg-gray-100 transition-colors shadow-md">


### PR DESCRIPTION
The button is added in the post-guess page. Atm, it breaks a bit since the songs used for the daily songs do not have the id stored. It's not a biggie but I'll sit down later and fix it but i'm opening the pr anyways so that we can review the changes atleast. 